### PR TITLE
fix(React): consider MenuItemData's show function in Menu Component

### DIFF
--- a/packages/react/src/shared-overlays/components/Menu/Menu.tsx
+++ b/packages/react/src/shared-overlays/components/Menu/Menu.tsx
@@ -30,6 +30,8 @@ export function Menu({
         {items.map((item, index) => {
           if (item === "divider") {
             return <$MenuDivider key={index} />
+          } else if (item.show && !item.show(editor)) {
+            return null
           } else {
             return (
               <MenuItem


### PR DESCRIPTION
The [document](https://www.wysimark.com/docs/react) said:
>upload attachments and images features will be disabled

But the relative menu is still popover when these features is in `compactDialogItems` which I find the relative configuration is in `packages/react/src/toolbar-plugin/items/dialogItems.tsx`. 

like this:

<img width="565" alt="before" src="https://github.com/portive/wysimark/assets/11785335/cc9b5231-48fe-4eee-9e1a-7dfc72d41e82">


It seems that the MenuItemData 's `show` function is only called in `ToolbarItem` Component, but not considered when the  in `Menu` Component (packages/react/src/shared-overlays/components/Menu/Menu.tsx). 

after this pr, when auth token is not given, the popover menu will looks like this:
<img width="494" alt="after" src="https://github.com/portive/wysimark/assets/11785335/d4021ac4-9f5a-4012-97b4-93171fc9c1d5">

