### PR TITLE
The pseudo class ":first-child" is potentially unsafe when doing serv…

### DIFF
--- a/packages/react/src/collapsible-paragraph-plugin/render-element/styles.ts
+++ b/packages/react/src/collapsible-paragraph-plugin/render-element/styles.ts
@@ -3,7 +3,7 @@ import styled from "@emotion/styled"
 export const $Paragraph = styled("p")`
   padding: 0;
   margin: 1em 0;
-  &:first-child {
+  &:first-of-type {
     margin-top: 0;
   }
 

--- a/packages/react/src/heading-plugin/styles.ts
+++ b/packages/react/src/heading-plugin/styles.ts
@@ -3,7 +3,7 @@ import styled from "@emotion/styled"
 
 const headingStyles = css`
   margin-top: 1em;
-  &:first-child {
+  &:first-of-type {
     margin-top: 0;
   }
   font-weight: bold;

--- a/packages/react/src/upload-plugin/store/create-upload-store.ts
+++ b/packages/react/src/upload-plugin/store/create-upload-store.ts
@@ -1,4 +1,4 @@
-import create from "zustand"
+import { create } from "zustand"
 
 import { Upload } from "../types"
 import { UploadStore } from "./index"


### PR DESCRIPTION
I'm getting the javascript warning:

The pseudo class ":first-child" is potentially unsafe when doing server-side rendering. Try changing it to ":first-of-type".

I've changed all pseudo class useages of `:first-child` with `:first-of-type`

Never made minified versions before so i don't really know how that is handled but perhaps this makes life a little easier for you to implement the fix.